### PR TITLE
adding baseURL type and enforcing trailing slash FromConfig

### DIFF
--- a/webserver/src/components/Navbar.jsx
+++ b/webserver/src/components/Navbar.jsx
@@ -15,7 +15,7 @@ export default function ResponsiveAppBar() {
   const [schedule, setschedule] = useState("")
 
   function fetchData() {
-    http.get('/api/stats/current')
+    http.get('./api/stats/current')
     .then(data => {
       const timeDiffMs = data.timeDiff / 1000_000;
       const now = new Date();
@@ -27,14 +27,14 @@ export default function ResponsiveAppBar() {
 
       setrunning(data.running);
     });
-    http.get('/api/schedule').then((data) => {
+    http.get('./api/schedule').then((data) => {
       const nextRun = data ? parseJSON(data) : new Date();
       setschedule(formatDistanceToNow(nextRun, { addSuffix: true }));
     });
   }
 
   function runCheckrr() {
-    http.post("/api/run", {});
+    http.post("./api/run", {});
   }
 
   useEffect(() => {

--- a/webserver/src/components/Stats.jsx
+++ b/webserver/src/components/Stats.jsx
@@ -22,7 +22,7 @@ export default function Stats() {
   }, []);
 
   function fetchData() {
-    http.get('/api/stats/current')
+    http.get('./api/stats/current')
     .then(stats => {
         let labels = []
         let data = []
@@ -51,7 +51,7 @@ export default function Stats() {
         }
         setpiedata(piedata)
     })
-    http.get('/api/stats/historical')
+    http.get('./api/stats/historical')
     .then(data => {
       // Fix the data so it's ready for chart.js
       let sortedData = { sonarrSubmissions: [], radarrSubmissions: [], lidarrSubmissions: [], filesChecked: [], hashMatches: [],

--- a/webserver/src/components/Table.jsx
+++ b/webserver/src/components/Table.jsx
@@ -37,7 +37,7 @@ export default function DataTable() {
   };
 
   function fetchData() {
-    http.get(`/api/files/bad`)
+    http.get(`./api/files/bad`)
     .then(data => {
         const rows = data?.map((l, i) => ({
           id: i + 1,
@@ -124,7 +124,7 @@ export default function DataTable() {
           </Typography>
           <Grid>
               <Button color="warning" onClick={() => {
-              http.post('/api/files/bad', selectedRows).then(() => {
+              http.post('./api/files/bad', selectedRows).then(() => {
                 setdisplayModal(false)
                 window.location.reload(false)
           })}}>Delete</Button>

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -24,7 +24,7 @@ var staticFS embed.FS
 
 var fileInfo [][]string
 
-var baseurl string
+var baseurl BaseURL
 
 var db *bolt.DB
 var scheduler *cron.Cron
@@ -33,15 +33,30 @@ var checkrrInstance *check.Checkrr
 
 type Webserver struct {
 	Port           int
-	BaseURL        string
+	BaseURL        BaseURL
 	data           chan []string
 	trustedProxies []string
 	DB             *bolt.DB
 }
 
+type BaseURL string
+
+// EnforceTrailingSlash ensures that the base URL has a trailing slash.
+func (b BaseURL) EnforceTrailingSlash() BaseURL {
+	if !strings.HasSuffix(string(b), "/") {
+		return BaseURL(string(b) + "/")
+	}
+	return b
+}
+
+// String returns the base URL as a string.
+func (b BaseURL) String() string {
+	return string(b)
+}
+
 func (w *Webserver) FromConfig(conf *viper.Viper, c chan []string, checkrr *check.Checkrr) {
 	w.Port = conf.GetInt("Port")
-	w.BaseURL = conf.GetString("baseurl")
+	w.BaseURL = BaseURL(conf.GetString("baseurl")).EnforceTrailingSlash()
 	baseurl = w.BaseURL
 	if conf.GetStringSlice("trustedproxies") != nil {
 		w.trustedProxies = conf.GetStringSlice("trustedproxies")
@@ -89,8 +104,8 @@ func createServer(w *Webserver) *gin.Engine {
 
 	router := gin.Default()
 	router.SetTrustedProxies(w.trustedProxies)
-	router.Use(static.Serve(w.BaseURL, embeddedBuildFolder))
-	api := router.Group(w.BaseURL + "api")
+	router.Use(static.Serve(w.BaseURL.String(), embeddedBuildFolder))
+	api := router.Group(w.BaseURL.String() + "api")
 	api.GET("/files/bad", getBadFiles)
 	api.POST("/files/bad", deleteBadFiles)
 	api.GET("/stats/current", getCurrentStats)
@@ -228,7 +243,7 @@ func (s *staticFileSystem) Exists(prefix string, path string) bool {
 	if baseurl == "/" {
 		buildpath = fmt.Sprintf("build%s", path)
 	} else {
-		buildpath = fmt.Sprintf("build%s", strings.TrimPrefix(path, baseurl))
+		buildpath = fmt.Sprintf("build%s", strings.TrimPrefix(path, baseurl.String()))
 	}
 
 	// support for folders

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -241,9 +241,9 @@ func newStaticFileSystem() *staticFileSystem {
 func (s *staticFileSystem) Exists(prefix string, path string) bool {
 	buildpath := ""
 	if baseurl == "/" {
-		buildpath = fmt.Sprintf("build%s", path)
+		buildpath = fmt.Sprintf("build/%s", path)
 	} else {
-		buildpath = fmt.Sprintf("build%s", strings.TrimPrefix(path, baseurl.String()))
+		buildpath = fmt.Sprintf("build/%s", strings.TrimPrefix(path, baseurl.String()))
 	}
 
 	// support for folders


### PR DESCRIPTION
Part of fixing [68](https://github.com/aetaric/checkrr/issues/68), this ensures that FromConfig loads baseURL with a trailing slash, and correcting the reference to your baseurl var is now a BaseURL type .String() wherever it was referenced.

Let me know if anything is to be changed 👍 🚀 