### PR TITLE
add webserver block to minimal config yaml

### DIFF
--- a/checkrr.yaml.minimal
+++ b/checkrr.yaml.minimal
@@ -13,3 +13,8 @@ checkrr:
     - .nfo
     - .nzb
     - .url
+webserver:
+  port: 8585
+  baseurl: "/"
+  trustedproxies:
+    - 127.0.0.1


### PR DESCRIPTION
added webserver block from example to minimal. without this, the container starts up without a valid listening port on the webserver