### PR TITLE
[Config formatting] Remove trailing spaces

### DIFF
--- a/checkrr.yaml.example
+++ b/checkrr.yaml.example
@@ -1,5 +1,5 @@
 checkrr:
-  checkpath: 
+  checkpath:
     - "/Movies/"
     - "/Movies-4k/"
     - "/tv/"
@@ -96,7 +96,7 @@ arr:
 notifications:
   discord:
     url: ""
-    notificationtypes: 
+    notificationtypes:
       - reacquire
       - unknowndetected
       - startrun
@@ -125,7 +125,7 @@ notifications:
       - endrun
   pushbullet:
     apitoken: ""
-    devices: 
+    devices:
       - myDevice1
       - iPhone14
     notificationtypes:


### PR DESCRIPTION
Noticed some trailing spaces on three lines in the config. Removed them.