### PR TITLE
Add detection of files without audio tracks (requireaudio option)

### DIFF
--- a/checkrr.yaml.example
+++ b/checkrr.yaml.example
@@ -11,6 +11,7 @@ checkrr:
   csvfile: "./badfiles.csv"
   cron: "@daily"
   ignorehidden: true
+  requireaudio: true
   ignorepaths:
     - '/tv/ignored'
   removevideo:

--- a/locale/locale.en.toml
+++ b/locale/locale.en.toml
@@ -349,3 +349,7 @@ other = "Elapsed Time"
 [StatsSplunkError]
 description = "Status code from Splunk"
 other = "Recieved {{.Code}} status code from Splunk"
+
+[CheckNoAudioStream]
+description = "No audio stream detected"
+other = "No Audio Stream detected for file: {{.Path}}. Removing."


### PR DESCRIPTION
# Add detection of files without audio tracks

## Description
This PR adds a new feature allowing Checkrr to detect video files that don't contain any audio track. When such a file is detected, it's flagged as problematic and processed according to the user's configuration (deletion or reacquisition via Sonarr/Radarr/Lidarr).

## New features
- Added configuration option `requireaudio: true|false` to enable/disable this check
- Implemented detection logic for missing audio tracks in the `checkFile()` function
- Added appropriate log messages to trace these detections

## How to test
1. Add `requireaudio: true` to your configuration file
2. Run Checkrr on a library containing video files without audio tracks
3. Check logs and notifications to confirm these files are properly detected

## Notes
Files without audio tracks are reported with reason "no audio streams" in the database and logs.