### PR TITLE
fix: add missing NotificationsTelegramError locale key

### DIFF
--- a/locale/locale.en.toml
+++ b/locale/locale.en.toml
@@ -381,3 +381,6 @@ other = "Recieved {{.Code}} status code from Splunk"
 [CheckNoAudioStream]
 description = "No audio stream detected"
 other = "No Audio Stream detected for file: {{.Path}}. Removing."
+[NotificationsTelegramError]
+description = "Error sending Telegram notification"
+other = "Error sending Telegram notification: {{.Error}}"


### PR DESCRIPTION
The Telegram notifier in `notifications/telegram.go` calls

```go
t.Localizer.MustLocalize(&i18n.LocalizeConfig{
    MessageID: "NotificationsTelegramError",
    TemplateData: map[string]interface{}{"Error": err.Error()},
})
```

on the connection-error path, but the `NotificationsTelegramError` key is absent from `locale/locale.en.toml`. `MustLocalize` panics on a missing message ID, so any Telegram delivery error (invalid token, network failure, blocked egress, etc.) crashes the process instead of being logged.

This patch adds the missing stanza so the error path can format and emit its message normally. Diff is 3 lines appended to `locale/locale.en.toml`; no code changes.

**Reproduction:** set an invalid `apitoken` (or block egress to `api.telegram.org`) and trigger any notification path. The process panics with a `MustLocalize: message ... not found` stack trace.

Verified locally against v3.6.1 source; the daily scheduled scan on a production instance reliably hit this whenever Telegram delivery failed.